### PR TITLE
poll error on c9800platformAccessory.js:92:108

### DIFF
--- a/c9800platformAccessory.js
+++ b/c9800platformAccessory.js
@@ -75,7 +75,7 @@ class C9800PlatformAccessory {
 			try {
 				const response = await this.platform.session({
 					method: 'get',
-					url: 'https://' + this.accessory.context.device.ipAddress+wlan_cfg_path + this.accessory.context.device.wlanList[i],
+					url: 'https://' + this.accessory.context.device.ipAddress+wlan_cfg_path + this.accessory.context.device.wlanList[i]+'/apf-vap-id-data/wlan-status',
 					data: {},
 					auth: {
 						username: this.accessory.context.device.username,
@@ -89,7 +89,7 @@ class C9800PlatformAccessory {
 				}).catch(err => {
 						this.platform.log.error('Error getting WLAN state %s',err)
 				})
-				const powerState = response["data"]["Cisco-IOS-XE-wireless-wlan-cfg:wlan-cfg-entry"]["apf-vap-id-data"]["wlan-status"];
+				const powerState = response["data"]["Cisco-IOS-XE-wireless-wlan-cfg:wlan-status"];
 				this.platform.log('Get WLAN state for %s = %s',  this.accessory.context.device.ssidList[i], (powerState === true))
 				this.accessory.services[i+1].getCharacteristic(Characteristic.On).updateValue(powerState === true)
 			}catch(err) {


### PR DESCRIPTION
tested on a 17.7.1 i got the following error.

```
Error getting WLAN state TypeError: Cannot read properties of undefined (reading 'wlan-status')
    at C9800PlatformAccessory.poll (/homebridge/node_modules/homebridge-c9800/c9800platformAccessory.js:92:108)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

changing the poll URL to append the path for wlan-status fixes it after also changing the powerstate const.